### PR TITLE
Исправили баг с пустой строкой при завершении времени на таймере

### DIFF
--- a/TestGI/FormTest.cs
+++ b/TestGI/FormTest.cs
@@ -29,6 +29,14 @@ namespace TestGI
 
         void  BreakTime(object sender, string message)
         {
+            try
+            {
+                double temp = Convert.ToDouble(textBoxUserAnswer.Text);
+            }
+            catch
+            {
+                textBoxUserAnswer.Text = "-1";
+            }
             MessageBox.Show(message);
             NextQuestion();
         }


### PR DESCRIPTION
Исправил с помощью try-catch: пытаюсь перевести в дабл текст с текстбокса, если не получается заменяю текст на -1